### PR TITLE
Port 6000 is X11's display 0.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,11 @@ Got a copy of the code? Want to tinker with it? Great.
 
         ./gradlew stage
 
-2. Start the server. By default, it runs on port 6000, but you can change the port with the `PORT` environment variable:
+2. Start the server. By default, it runs on port 5000, but you can change the port with the `PORT` environment variable:
 
         java -jar build/libs/login-box-all.jar server
 
-3. Visit http://localhost:6000/ to open the app.
+3. Visit http://localhost:5000/ to open the app.
 
 To shut down the server, hit Ctrl-C (Ctrl-Break on Windows).
 

--- a/src/main/java/com/loginbox/heroku/http/HerokuConnectorFactory.java
+++ b/src/main/java/com/loginbox/heroku/http/HerokuConnectorFactory.java
@@ -37,7 +37,7 @@ public class HerokuConnectorFactory extends HttpConnectorFactory {
     /**
      * The default HTTP port, used if
      */
-    public static final int DEFAULT_PORT = 6000;
+    public static final int DEFAULT_PORT = 5000;
 
     private static final Logger LOG = LoggerFactory.getLogger(HerokuConnectorFactory.class);
 


### PR DESCRIPTION
Maybe we should leave other peoples' port ranges alone. Since the default port under foreman is port 5000, why not make that the default behaviour without foreman, too?