### PR TITLE
Upgrade dropwizard-heroku.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ dependencies {
 
     compile group: 'io.dropwizard', name: 'dropwizard-core', version: dropwizardVersion
     compile group: 'io.dropwizard', name: 'dropwizard-assets', version: dropwizardVersion
-    compile group: 'com.loginbox.heroku', name: 'dropwizard-heroku-config', version: '0.1.0'
+    compile group: 'com.loginbox.heroku', name: 'dropwizard-heroku-config', version: '0.1.1'
 
     testCompile group: 'junit', name: 'junit', version: '4.12'
     testCompile group: 'org.hamcrest', name: 'hamcrest-core', version: hamcrestVersion


### PR DESCRIPTION
The new version suppresses the default request logging from Dropwizard.