### PR TITLE
Get the build badge out of the way, visually.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
-# Login Box
+# Login Box [![Build Status](https://circleci.com/gh/login-box/login-box.svg)](https://circleci.com/gh/login-box/login-box)
 
 [![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy)
-
-[![Build Status](https://circleci.com/gh/login-box/login-box.svg)](https://circleci.com/gh/login-box/login-box)
 
 An easy-to-deploy login server for your applications.
 


### PR DESCRIPTION
Moving it to the heading makes the Heroku deploy button -- the most important
thing on the page -- stand out more.