### PR TITLE
When building pull requests, build the merge result.

### DIFF
--- a/bin/use-pull-request-merge
+++ b/bin/use-pull-request-merge
@@ -1,0 +1,8 @@
+#!/bin/bash -e
+
+if [ -z "${CIRCLE_PR_NUMBER}" ]; then
+    exit 0
+fi
+
+git fetch origin "refs/pull/${CIRCLE_PR_NUMBER}/merge"
+git checkout FETCH_HEAD

--- a/circle.yml
+++ b/circle.yml
@@ -3,6 +3,10 @@ machine:
     java:
         version: oraclejdk8
 
+checkout:
+    post:
+        - bin/use-pull-request-merge
+
 dependencies:
     post:
         - ./gradlew stage


### PR DESCRIPTION
This permits testing pull requests in tandem with master, making the build
marginally less reproducible (it now depends on the state of both the pull
request branch and its target branch, rather than on the state of the pull
request branch alone) but gives better confidence that the merge result is sane.