### PR TITLE
Extracted test scaffolding for bundles.

### DIFF
--- a/src/test/java/com/loginbox/app/LoginBoxTest.java
+++ b/src/test/java/com/loginbox/app/LoginBoxTest.java
@@ -3,6 +3,7 @@ package com.loginbox.app;
 import com.loginbox.app.csrf.CsrfBundle;
 import com.loginbox.app.csrf.mybatis.MybatisCsrfBundle;
 import com.loginbox.app.csrf.ui.CsrfUiBundle;
+import com.loginbox.app.dropwizard.BundleTestCase;
 import com.loginbox.app.version.VersionBundle;
 import com.loginbox.app.views.ViewBundle;
 import com.loginbox.dropwizard.mybatis.MybatisBundle;
@@ -15,11 +16,12 @@ import static org.mockito.Mockito.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-public class LoginBoxTest {
-    private final Bootstrap<LoginBoxConfiguration> bootstrap = mock(Bootstrap.class);
+public class LoginBoxTest extends BundleTestCase {
     private final LoginBox application = new LoginBox();
 
     @Test
+    /* following _should_ be for the MybatisBundle expectation. */
+    @SuppressWarnings("unchecked")
     public void configuresExpectedBundles() {
         /* This is a dumb test: it more or less reiterates the body of the methods under test. However, it's better than nothing, I hope... */
         application.initialize(bootstrap);

--- a/src/test/java/com/loginbox/app/csrf/CsrfBundleTest.java
+++ b/src/test/java/com/loginbox/app/csrf/CsrfBundleTest.java
@@ -2,6 +2,7 @@ package com.loginbox.app.csrf;
 
 import com.loginbox.app.csrf.context.CsrfCookies;
 import com.loginbox.app.csrf.context.CsrfValidator;
+import com.loginbox.app.dropwizard.BundleTestCase;
 import io.dropwizard.jersey.setup.JerseyEnvironment;
 import io.dropwizard.setup.Environment;
 import org.junit.Before;
@@ -12,16 +13,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class CsrfBundleTest {
+public class CsrfBundleTest extends BundleTestCase {
     private final CsrfBundle bundle = new CsrfBundle();
-
-    private final Environment environment = mock(Environment.class);
-    private final JerseyEnvironment jersey = mock(JerseyEnvironment.class);
-
-    @Before
-    public void wireMocks() {
-        when(environment.jersey()).thenReturn(jersey);
-    }
 
     @Test
     public void bindsValidator() {

--- a/src/test/java/com/loginbox/app/dropwizard/BundleTestCase.java
+++ b/src/test/java/com/loginbox/app/dropwizard/BundleTestCase.java
@@ -1,0 +1,22 @@
+package com.loginbox.app.dropwizard;
+
+import com.loginbox.app.LoginBoxConfiguration;
+import io.dropwizard.jersey.setup.JerseyEnvironment;
+import io.dropwizard.setup.Bootstrap;
+import io.dropwizard.setup.Environment;
+import org.junit.Before;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class BundleTestCase {
+    @SuppressWarnings("unchecked")
+    protected final Bootstrap<LoginBoxConfiguration> bootstrap = mock(Bootstrap.class);
+    protected final Environment environment = mock(Environment.class);
+    protected final JerseyEnvironment jersey = mock(JerseyEnvironment.class);
+
+    @Before
+    public void wireMocks() {
+        when(environment.jersey()).thenReturn(jersey);
+    }
+}

--- a/src/test/java/com/loginbox/app/views/ViewBundleTest.java
+++ b/src/test/java/com/loginbox/app/views/ViewBundleTest.java
@@ -1,6 +1,7 @@
 package com.loginbox.app.views;
 
 import com.loginbox.app.LoginBoxConfiguration;
+import com.loginbox.app.dropwizard.BundleTestCase;
 import io.dropwizard.jersey.setup.JerseyEnvironment;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
@@ -13,18 +14,12 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class ViewBundleTest {
-    private final Bootstrap<LoginBoxConfiguration> bootstrap = mock(Bootstrap.class);
-    private final JerseyEnvironment jersey = mock(JerseyEnvironment.class);
-    private final Environment environment = mock(Environment.class);
+public class ViewBundleTest extends BundleTestCase {
     private final ViewBundle bundle = new ViewBundle();
 
-    @Before
-    public void wireMocks() {
-        when(environment.jersey()).thenReturn(jersey);
-    }
-
     @Test
+    /* This _should_ be catching the warning from the ViewBundle expectation. */
+    @SuppressWarnings("unchecked")
     public void configuresBundles() {
         bundle.initialize(bootstrap);
 


### PR DESCRIPTION
Turns out:

1. there are some ugly type conversion warnings that I'd prefer only to suppress
    once, so that it only has to be sanity-checked once, and
2. there's a lot of redundancy in this code that doesn't need to exist.