### PR TITLE
Standard MIME types.

### DIFF
--- a/README/mime.md
+++ b/README/mime.md
@@ -1,0 +1,20 @@
+# MIME Types
+
+Login Box supports two MIME types each for requests and for responses.
+Negotiation follows the HTTP/1.1 RFC, using the `Accept` header to decide which
+supported content type to return and the `Content-Type` header to decide which
+content type to parse in a request.
+
+The supported types are:
+
+* `application/x-login-box+json; version=1` - supported for both requests and
+    responses. This is a JSON-based type whose notional schema varies by
+    message. See the documentation for each endpoint for a description of the
+    schemata.
+
+* `text/html` - supported for responses only. This is HTML 5, with support for
+    browser-based rendering and interaction.
+
+* `application/x-www-form-urlencoded` - supported for requests only. This is
+    forms as described in HTML 5. Field names vary per message; see the
+    documentation for each endpoint.

--- a/src/main/java/com/loginbox/app/mime/Types.java
+++ b/src/main/java/com/loginbox/app/mime/Types.java
@@ -1,0 +1,26 @@
+package com.loginbox.app.mime;
+
+import javax.ws.rs.core.MediaType;
+
+import static com.loginbox.collections.MapLiteral.entry;
+import static com.loginbox.collections.MapLiteral.hashMap;
+
+/**
+ * Standard MIME types for Login Box. Most resources should use these constants, generally in the form of
+ * <pre>
+ *    {@literal @}Produces({Mime.TEXT_HTML, Mime.APPLICATION_LOGIN_BOX})
+ * </pre>
+ * or
+ * <pre>
+ *    {@literal @}Consumes({Mime.APPLICATION_FORM_URLENCODED, Mime.APPLICATION_LOGIN_BOX})
+ * </pre>
+ */
+public class Types {
+    public static final String TEXT_HTML = MediaType.TEXT_HTML;
+    public static final String APPLICATION_FORM_URLENCODED = MediaType.APPLICATION_FORM_URLENCODED;
+    public static final String APPLICATION_LOGIN_BOX = "application/x-login-box+json;version=1";
+
+    public static final MediaType APPLICATION_LOGIN_BOX_TYPE = new MediaType("application", "x-login-box+json", hashMap(
+            entry("version", "1")
+    ));
+}

--- a/src/main/java/com/loginbox/collections/MapLiteral.java
+++ b/src/main/java/com/loginbox/collections/MapLiteral.java
@@ -1,0 +1,55 @@
+package com.loginbox.collections;
+
+import java.util.HashMap;
+
+/**
+ * Support tools for creating maps without syntactic noise _or_ the awful initializer hack.
+ */
+public final class MapLiteral {
+    private MapLiteral() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Creates a new HashMap with the given entries. For example:
+     * <pre>
+     *     HashMap&lt;Integer, String&gt; m = hashMap(
+     *         entry(1, "foo"),
+     *         entry(3, "bar")
+     *     );
+     * </pre>
+     *
+     * @param entries
+     *         a sequence of map entries, usually from {@link #entry}.
+     * @param <K>
+     *         the key type of the resulting map.
+     * @param <V>
+     *         the value type of the resulting map.
+     * @return a map with all of the passed entries populated into it.
+     */
+    @SafeVarargs
+    public static <K, V> HashMap<K, V> hashMap(Entry<K, V>... entries) {
+        HashMap<K, V> map = new HashMap<>();
+        for (Entry<K, V> entry : entries)
+            entry.storeTo(map);
+        return map;
+    }
+
+    public static <K, V> Entry<K, V> entry(K key, V value) {
+        return new Entry<>(key, value);
+    }
+
+    public static class Entry<K, V> {
+        private final K key;
+        private final V value;
+
+        private Entry(K key, V value) {
+            this.key = key;
+            this.value = value;
+        }
+
+        private void storeTo(HashMap<K, V> map) {
+            map.put(key, value);
+        }
+    }
+}

--- a/src/test/java/com/loginbox/app/mime/TypesTest.java
+++ b/src/test/java/com/loginbox/app/mime/TypesTest.java
@@ -1,0 +1,14 @@
+package com.loginbox.app.mime;
+
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+public class TypesTest {
+    @Test
+    public void loginBoxTypes() {
+        assertThat(Types.APPLICATION_LOGIN_BOX,
+                equalTo(Types.APPLICATION_LOGIN_BOX_TYPE.toString()));
+    }
+}

--- a/src/test/java/com/loginbox/collections/MapLiteralTest.java
+++ b/src/test/java/com/loginbox/collections/MapLiteralTest.java
@@ -1,0 +1,33 @@
+package com.loginbox.collections;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+public class MapLiteralTest {
+    @Test
+    public void mapLiteral() {
+        HashMap<String, String> expected = new HashMap<>();
+        expected.put("3", "three");
+        expected.put("5", "five");
+
+        HashMap<String, String> actual = MapLiteral.hashMap(
+                MapLiteral.entry("3", "three"),
+                MapLiteral.entry("5", "five")
+        );
+
+        assertThat(actual, is(equalTo(expected)));
+    }
+
+    @Test
+    public void emptyMapLiteral() {
+        HashMap<String, String> actual = MapLiteral.hashMap();
+
+        assertThat(actual.entrySet(), is(empty()));
+    }
+}


### PR DESCRIPTION
The `Types` class provides constants for the MIME types used in Login Box, to
help cut down on duplication and typos. I can't centralize it further:

    @Produces(Mime.STANDARD_TYPES)

would require features Java lacks at a language level, such as array-typed
constant expressions.

I've also introduced map pseudo-literals, because their absence in 2015 is
embarassing.