### PR TITLE
Set up a default landing page.

### DIFF
--- a/src/main/java/com/loginbox/app/LoginBox.java
+++ b/src/main/java/com/loginbox/app/LoginBox.java
@@ -3,6 +3,7 @@ package com.loginbox.app;
 import com.loginbox.app.csrf.CsrfBundle;
 import com.loginbox.app.csrf.mybatis.MybatisCsrfBundle;
 import com.loginbox.app.csrf.ui.CsrfUiBundle;
+import com.loginbox.app.landing.LandingBundle;
 import com.loginbox.app.version.VersionBundle;
 import com.loginbox.app.views.ViewBundle;
 import com.loginbox.dropwizard.mybatis.MybatisBundle;
@@ -47,6 +48,7 @@ public class LoginBox extends Application<LoginBoxConfiguration> {
         }
     };
     private final CsrfUiBundle csrfUiBundle = new CsrfUiBundle();
+    private final LandingBundle landingBundle = new LandingBundle();
 
     @Override
     public void initialize(Bootstrap<LoginBoxConfiguration> bootstrap) {
@@ -58,6 +60,7 @@ public class LoginBox extends Application<LoginBoxConfiguration> {
         bootstrap.addBundle(csrfBundle);
         bootstrap.addBundle(mybatisCsrfBundle);
         bootstrap.addBundle(csrfUiBundle);
+        bootstrap.addBundle(landingBundle);
     }
 
     @Override

--- a/src/main/java/com/loginbox/app/landing/LandingBundle.java
+++ b/src/main/java/com/loginbox/app/landing/LandingBundle.java
@@ -1,0 +1,27 @@
+package com.loginbox.app.landing;
+
+import com.loginbox.app.landing.resources.LandingResource;
+import io.dropwizard.Bundle;
+import io.dropwizard.setup.Bootstrap;
+import io.dropwizard.setup.Environment;
+
+/**
+ * Registers Login Box's landing page and config reporter.
+ */
+public class LandingBundle implements Bundle {
+    @Override
+    public void initialize(Bootstrap<?> bootstrap) {
+
+    }
+
+    /**
+     * Registers the following resources: <ul> <li>{@link com.loginbox.app.landing.resources.LandingResource}</li>
+     * </ul>
+     */
+    @Override
+    public void run(Environment environment) {
+        LandingResource landingResource = new LandingResource();
+
+        environment.jersey().register(landingResource);
+    }
+}

--- a/src/main/java/com/loginbox/app/landing/api/LandingPage.java
+++ b/src/main/java/com/loginbox/app/landing/api/LandingPage.java
@@ -1,0 +1,9 @@
+package com.loginbox.app.landing.api;
+
+import com.loginbox.app.views.ViewConvention;
+
+public class LandingPage extends ViewConvention {
+    public LandingPage() {
+        super("landing-page.ftl");
+    }
+}

--- a/src/main/java/com/loginbox/app/landing/resources/LandingResource.java
+++ b/src/main/java/com/loginbox/app/landing/resources/LandingResource.java
@@ -1,0 +1,26 @@
+package com.loginbox.app.landing.resources;
+
+import com.loginbox.app.landing.api.LandingPage;
+import com.loginbox.app.mime.Types;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+
+/**
+ * Returns Login Box's default landing page. This is a temporary arrangement (yes, yes, famous last words) until user
+ * login exists.
+ */
+@Path("/")
+public class LandingResource {
+    /**
+     * Displays the default landing page.
+     *
+     * @return the default landing page.
+     */
+    @GET
+    @Produces({Types.TEXT_HTML, Types.APPLICATION_LOGIN_BOX})
+    public LandingPage hello() {
+        return new LandingPage();
+    }
+}

--- a/src/test/java/com/loginbox/app/LoginBoxTest.java
+++ b/src/test/java/com/loginbox/app/LoginBoxTest.java
@@ -4,16 +4,15 @@ import com.loginbox.app.csrf.CsrfBundle;
 import com.loginbox.app.csrf.mybatis.MybatisCsrfBundle;
 import com.loginbox.app.csrf.ui.CsrfUiBundle;
 import com.loginbox.app.dropwizard.BundleTestCase;
+import com.loginbox.app.landing.LandingBundle;
 import com.loginbox.app.version.VersionBundle;
 import com.loginbox.app.views.ViewBundle;
 import com.loginbox.dropwizard.mybatis.MybatisBundle;
 import io.dropwizard.assets.AssetsBundle;
 import io.dropwizard.migrations.MigrationsBundle;
-import io.dropwizard.setup.Bootstrap;
 import org.junit.Test;
 
 import static org.mockito.Mockito.isA;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 public class LoginBoxTest extends BundleTestCase {
@@ -34,5 +33,6 @@ public class LoginBoxTest extends BundleTestCase {
         verify(bootstrap).addBundle(isA(CsrfBundle.class));
         verify(bootstrap).addBundle(isA(MybatisCsrfBundle.class));
         verify(bootstrap).addBundle(isA(CsrfUiBundle.class));
+        verify(bootstrap).addBundle(isA(LandingBundle.class));
     }
 }

--- a/src/test/java/com/loginbox/app/landing/LandingBundleTest.java
+++ b/src/test/java/com/loginbox/app/landing/LandingBundleTest.java
@@ -1,0 +1,19 @@
+package com.loginbox.app.landing;
+
+import com.loginbox.app.dropwizard.BundleTestCase;
+import com.loginbox.app.landing.resources.LandingResource;
+import org.junit.Test;
+
+import static org.mockito.Mockito.isA;
+import static org.mockito.Mockito.verify;
+
+public class LandingBundleTest extends BundleTestCase {
+    private final LandingBundle bundle = new LandingBundle();
+
+    @Test
+    public void registersResources() {
+        bundle.run(environment);
+
+        verify(jersey).register(isA(LandingResource.class));
+    }
+}

--- a/src/test/java/com/loginbox/app/landing/resources/LandingResourceTest.java
+++ b/src/test/java/com/loginbox/app/landing/resources/LandingResourceTest.java
@@ -1,0 +1,19 @@
+package com.loginbox.app.landing.resources;
+
+import com.loginbox.app.landing.api.LandingPage;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.*;
+import static org.hamcrest.MatcherAssert.*;
+import static org.mockito.Mockito.*;
+
+public class LandingResourceTest {
+    private final LandingResource resource = new LandingResource();
+
+    @Test
+    public void returnsLandingPage() {
+        LandingPage landingPage = resource.hello();
+
+        assertThat(landingPage, is(not(nullValue())));
+    }
+}


### PR DESCRIPTION
This is not the behaviour Login Box should ultimately exhibit. However, the
_actual_ behaviour can't be implemented yet, and a bunch of upcoming features
need _something_ to hang off of: for example, the initial setup mode needs to
happen somehow, and this is a good way to kick that off.