### PR TITLE
Add missing templates for / and /admin.

### DIFF
--- a/src/acceptanceTest/java/com/loginbox/app/acceptance/framework/driver/AdminPageDriver.java
+++ b/src/acceptanceTest/java/com/loginbox/app/acceptance/framework/driver/AdminPageDriver.java
@@ -1,0 +1,20 @@
+package com.loginbox.app.acceptance.framework.driver;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+public class AdminPageDriver extends SeleniumDriver {
+    public AdminPageDriver(SystemDriver systemDriver) {
+        super(systemDriver);
+    }
+
+    public String getAdminHeading() {
+        return findPageHeading()
+                .getText();
+    }
+
+    @Deprecated
+    public void open() {
+        webDriver().navigate().to(systemDriver.baseUrl() + "admin");
+    }
+}

--- a/src/acceptanceTest/java/com/loginbox/app/acceptance/framework/driver/LandingPageDriver.java
+++ b/src/acceptanceTest/java/com/loginbox/app/acceptance/framework/driver/LandingPageDriver.java
@@ -1,0 +1,14 @@
+package com.loginbox.app.acceptance.framework.driver;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class LandingPageDriver extends SeleniumDriver {
+    public LandingPageDriver(SystemDriver systemDriver) {
+        super(systemDriver);
+    }
+
+    public void assertLandingPageShown() {
+        assertThat(findPageHeading().getText(), is("Login Box"));
+    }
+}

--- a/src/acceptanceTest/java/com/loginbox/app/acceptance/framework/driver/SeleniumDriver.java
+++ b/src/acceptanceTest/java/com/loginbox/app/acceptance/framework/driver/SeleniumDriver.java
@@ -37,4 +37,14 @@ public abstract class SeleniumDriver {
         return webDriver()
                 .findElement(by);
     }
+
+    /**
+     * Shorthand for <code>findElement(By.tagName("h1"))</code>. This is a common case for inspecting the page's title
+     * heading.
+     *
+     * @see #findElement(org.openqa.selenium.By)
+     */
+    protected WebElement findPageHeading() {
+        return findElement(By.tagName("h1"));
+    }
 }

--- a/src/acceptanceTest/java/com/loginbox/app/acceptance/framework/driver/SystemDriver.java
+++ b/src/acceptanceTest/java/com/loginbox/app/acceptance/framework/driver/SystemDriver.java
@@ -1,6 +1,5 @@
 package com.loginbox.app.acceptance.framework.driver;
 
-
 import com.loginbox.app.LoginBox;
 import com.loginbox.app.LoginBoxConfiguration;
 import com.loginbox.app.acceptance.framework.Lazily;
@@ -40,6 +39,8 @@ public class SystemDriver {
     private Client publicApiClient = null;
     private WebUiDriver webUiDriver = null;
     private PublicApiDriver publicApiDriver = null;
+    private AdminPageDriver adminPageDriver = null;
+    private LandingPageDriver landingPageDriver = null;
 
     /**
      * Returns the current session's {@link org.openqa.selenium.WebDriver}, starting it if necessary. Callers
@@ -103,6 +104,14 @@ public class SystemDriver {
 
     public String baseUrl() {
         return baseUrl = Lazily.create(baseUrl, () -> String.format("http://localhost:%d/", appRule.getLocalPort()));
+    }
+
+    public AdminPageDriver adminPageDriver() {
+        return adminPageDriver = Lazily.create(adminPageDriver, () -> new AdminPageDriver(this));
+    }
+
+    public LandingPageDriver landingPageDriver() {
+        return landingPageDriver = Lazily.create(landingPageDriver, () -> new LandingPageDriver(this));
     }
 
     public TestRule rules() {

--- a/src/acceptanceTest/java/com/loginbox/app/acceptance/framework/page/AdminPage.java
+++ b/src/acceptanceTest/java/com/loginbox/app/acceptance/framework/page/AdminPage.java
@@ -1,0 +1,30 @@
+package com.loginbox.app.acceptance.framework.page;
+
+import com.loginbox.app.acceptance.framework.context.TestContext;
+import com.loginbox.app.acceptance.framework.driver.AdminPageDriver;
+
+import java.util.function.Supplier;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+/**
+ * DSL pack for manipulating the app configuration via its administration panel.
+ */
+public class AdminPage extends Dsl<AdminPageDriver> {
+    public AdminPage(Supplier<AdminPageDriver> driverFactory, TestContext testContext) {
+        super(driverFactory, testContext);
+    }
+
+    /**
+     * Checks that the browser is currently on the admin landing page.
+     */
+    public void ensureAdminShown() {
+        assertThat(driver().getAdminHeading(), is("Administer Login Box"));
+    }
+
+    @Deprecated
+    public void open() {
+        driver().open();
+    }
+}

--- a/src/acceptanceTest/java/com/loginbox/app/acceptance/framework/page/LandingPage.java
+++ b/src/acceptanceTest/java/com/loginbox/app/acceptance/framework/page/LandingPage.java
@@ -1,0 +1,22 @@
+package com.loginbox.app.acceptance.framework.page;
+
+import com.loginbox.app.acceptance.framework.context.TestContext;
+import com.loginbox.app.acceptance.framework.driver.LandingPageDriver;
+
+import java.util.function.Supplier;
+
+/**
+ * DSL pack for interacting with the landing page.
+ */
+public class LandingPage extends Dsl<LandingPageDriver> {
+    public LandingPage(Supplier<? extends LandingPageDriver> driverFactory, TestContext testContext) {
+        super(driverFactory, testContext);
+    }
+
+    /**
+     * Verifies that the browser is currently displaying the landing page.
+     */
+    public void ensureLandingPageShown() {
+        driver().assertLandingPageShown();
+    }
+}

--- a/src/acceptanceTest/java/com/loginbox/app/acceptance/framework/page/WebUi.java
+++ b/src/acceptanceTest/java/com/loginbox/app/acceptance/framework/page/WebUi.java
@@ -12,8 +12,20 @@ import static org.hamcrest.Matchers.is;
  * application's state, such as opening the application.
  */
 public class WebUi extends Dsl<WebUiDriver> {
+    /**
+     * Nested DSL for configuring the app.
+     */
+    public final AdminPage adminPage;
+
+    /**
+     * Nested DSL for the landing page.
+     */
+    public final LandingPage landingPage;
+
     public WebUi(SystemDriver systemDriver, TestContext testContext) {
         super(systemDriver::webUiDriver, testContext);
+        this.adminPage = new AdminPage(systemDriver::adminPageDriver, testContext);
+        this.landingPage = new LandingPage(systemDriver::landingPageDriver, testContext);
     }
 
     /**

--- a/src/acceptanceTest/java/com/loginbox/app/acceptance/tests/AdminTest.java
+++ b/src/acceptanceTest/java/com/loginbox/app/acceptance/tests/AdminTest.java
@@ -1,0 +1,12 @@
+package com.loginbox.app.acceptance.tests;
+
+import com.loginbox.app.acceptance.framework.DslTestCase;
+import org.junit.Test;
+
+public class AdminTest extends DslTestCase {
+    @Test
+    public void hasAdminPage() {
+        webUi.adminPage.open();
+        webUi.adminPage.ensureAdminShown();
+    }
+}

--- a/src/acceptanceTest/java/com/loginbox/app/acceptance/tests/LandingPageTest.java
+++ b/src/acceptanceTest/java/com/loginbox/app/acceptance/tests/LandingPageTest.java
@@ -3,9 +3,10 @@ package com.loginbox.app.acceptance.tests;
 import com.loginbox.app.acceptance.framework.DslTestCase;
 import org.junit.Test;
 
-public class BootTest extends DslTestCase {
+public class LandingPageTest extends DslTestCase {
     @Test
-    public void boot() {
+    public void hasLandingPage() {
         webUi.open();
+        webUi.landingPage.ensureLandingPageShown();
     }
 }

--- a/src/main/resources/com/loginbox/app/admin/api/admin.ftl
+++ b/src/main/resources/com/loginbox/app/admin/api/admin.ftl
@@ -1,0 +1,10 @@
+<#ftl strip_whitespace=true>
+<#import '/ftl/ui.ftl' as ui>
+<#-- @ftlvariable name="" type="com.loginbox.app.admin.api.AdminPage" -->
+<#escape name as name?html>
+<@ui.page title="Administer Login Box">
+    <div class="container">
+        <h1>Administer Login Box</h1>
+    </div>
+</@ui.page>
+</#escape>

--- a/src/main/resources/com/loginbox/app/landing/api/landing-page.ftl
+++ b/src/main/resources/com/loginbox/app/landing/api/landing-page.ftl
@@ -1,0 +1,20 @@
+<#ftl strip_whitespace=true>
+<#import '/ftl/ui.ftl' as ui>
+<#-- @ftlvariable name="" type="com.loginbox.app.landing.api.LandingPage" -->
+<#escape name as name?html>
+<@ui.page title="Login Box">
+    <div class="container">
+        <h1>Login Box</h1>
+        <p>If you are seeing this page, <em>congratulations</em>! You have completed first-time setup. Your setup will
+            be preserved in future releases.</p>
+        <p>This page is a temporary placeholder during development. In the completed system, this page will be replaced:</p>
+        <ul>
+            <li>with a redirect to a login page, if you are human and not logged in</li>
+            <li>with a redirect to your profile, if you are human and logged in</li>
+            <li>with API info about this Login Box instance, if you are a machine and logged in</li>
+            <li>with a 401 Not Authorized, if you are a machine and not logged in</li>
+        </ul>
+        <p>... Well, probably.</p>
+    </div>
+</@ui.page>
+</#escape>


### PR DESCRIPTION
When I extracted those endpoints from a big, omnibus branch, I thought, "I
don't need to test these, there's no way it could break."

I regret this decision.

I've used `@Deprecated` for the offending tests and support methods, since the
feature now under test should be removed later and replaced.