### PR TITLE
Update the default database plan to `hobby-dev`.

### DIFF
--- a/app.json
+++ b/app.json
@@ -11,7 +11,7 @@
     "postdeploy": "bin/run db migrate"
   },
   "addons": [
-    "heroku-postgresql:dev"
+    "heroku-postgresql:hobby-dev"
   ],
   "buildpacks": [
     {


### PR DESCRIPTION
Somewhere along the line, Heroku added tiers to the PostgreSQL addon plan names. The free "dev" plan is now "hobby-dev".