### PR TITLE
Be more resilient to builds on systems with no `git`.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+import com.loginbox.build.Versions
+
 plugins {
     id 'application'
     id 'com.github.johnrengelman.shadow' version '1.2.2'
@@ -10,9 +12,7 @@ group = 'com.loginbox.app'
 mainClassName = 'com.loginbox.app.LoginBox'
 
 ext {
-    sourceVersion = System.getenv('SOURCE_VERSION') ?:
-                        "git rev-parse HEAD".execute().text.trim() ?:
-                        'UNKNOWN'
+    sourceVersion = Versions.detect()
 }
 
 sourceCompatibility = '1.8'

--- a/buildSrc/.gitignore
+++ b/buildSrc/.gitignore
@@ -1,0 +1,2 @@
+/.gradle/
+/build/

--- a/buildSrc/src/main/groovy/com/loginbox/build/Versions.groovy
+++ b/buildSrc/src/main/groovy/com/loginbox/build/Versions.groovy
@@ -1,0 +1,23 @@
+package com.loginbox.build
+
+class Versions {
+    static String detect() {
+        envVersion() ?: gitVersion() ?: defaultVersion()
+    }
+
+    static String envVersion() {
+        System.getenv('SOURCE_VERSION')
+    }
+
+    static String gitVersion() {
+        try {
+            "git rev-parse HEAD".execute().text.trim()
+        } catch (IOException ioe) {
+            null
+        }
+    }
+
+    static String defaultVersion() {
+        "UNKNOWN"
+    }
+}


### PR DESCRIPTION
Thanks, @lewisd32!