### PR TITLE
Created an FTL helper for CSRF tokens.

### DIFF
--- a/app/src/main/resources/com/loginbox/app/setup/api/setup-form.ftl
+++ b/app/src/main/resources/com/loginbox/app/setup/api/setup-form.ftl
@@ -1,5 +1,6 @@
 <#ftl strip_whitespace=true>
 <#import '/ftl/ui.ftl' as ui>
+<#import '/ftl/csrf.ftl' as csrf>
 <#-- @ftlvariable name="" type="com.loginbox.app.setup.api.SetupForm" -->
 <#escape name as name?html>
 <@ui.html>
@@ -48,7 +49,7 @@
                                            name="confirmPassword"
                                            placeholder="Password">
                                 </div>
-                                <input type="hidden" name="csrfToken" value="${csrfToken.secret}">
+                                <@csrf.token />
                                 <button type="submit" class="btn btn-lg btn-default">Set It Up</button>
                             </form>
                         </div>

--- a/app/src/main/resources/ftl/csrf.ftl
+++ b/app/src/main/resources/ftl/csrf.ftl
@@ -1,0 +1,10 @@
+<#ftl strip_text=true strip_whitespace=true>
+<#-- @ftlvariable name="" type="com.loginbox.app.views.FormConvention" -->
+
+<#macro token>
+    <#escape name as name?html>
+        <#if csrfToken??>
+            <input type="hidden" name="csrfToken" value="${csrfToken.secret}">
+        </#if>
+    </#escape>
+</#macro>


### PR DESCRIPTION
Any `FormConvention` with a CSRF token can now be used in a form more easily:

    <form …>
        …
        <@csrf.token />
    </form>