### PR TITLE
Centralized `PasswordValidator` and made the round count configurable.

### DIFF
--- a/app/src/main/java/com/loginbox/app/LoginBox.java
+++ b/app/src/main/java/com/loginbox/app/LoginBox.java
@@ -5,6 +5,8 @@ import com.loginbox.app.csrf.CsrfBundle;
 import com.loginbox.app.csrf.mybatis.MybatisCsrfBundle;
 import com.loginbox.app.csrf.ui.CsrfUiBundle;
 import com.loginbox.app.landing.LandingBundle;
+import com.loginbox.app.password.PasswordBundle;
+import com.loginbox.app.password.PasswordValidator;
 import com.loginbox.app.setup.SetupBundle;
 import com.loginbox.app.version.VersionBundle;
 import com.loginbox.app.views.ViewBundle;
@@ -50,9 +52,15 @@ public class LoginBox extends Application<LoginBoxConfiguration> {
         }
     };
     private final CsrfUiBundle csrfUiBundle = new CsrfUiBundle();
+    private final PasswordBundle passwordBundle = new PasswordBundle();
     private final LandingBundle landingBundle = new LandingBundle();
     private final AdminBundle adminBundle = new AdminBundle();
     private final SetupBundle setupBundle = new SetupBundle() {
+        @Override
+        public PasswordValidator getPasswordValidator() {
+            return passwordBundle.getPasswordValidator();
+        }
+
         @Override
         public SqlSessionFactory getSqlSessionFactory() {
             return mybatisBundle.getSqlSessionFactory();
@@ -69,6 +77,7 @@ public class LoginBox extends Application<LoginBoxConfiguration> {
         bootstrap.addBundle(csrfBundle);
         bootstrap.addBundle(mybatisCsrfBundle);
         bootstrap.addBundle(csrfUiBundle);
+        bootstrap.addBundle(passwordBundle);
         bootstrap.addBundle(landingBundle);
         bootstrap.addBundle(adminBundle);
         bootstrap.addBundle(setupBundle);

--- a/app/src/main/java/com/loginbox/app/LoginBoxConfiguration.java
+++ b/app/src/main/java/com/loginbox/app/LoginBoxConfiguration.java
@@ -1,6 +1,7 @@
 package com.loginbox.app;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.loginbox.app.password.config.PasswordValidatorFactory;
 import com.loginbox.heroku.config.HerokuConfiguration;
 import com.loginbox.heroku.db.HerokuDataSourceFactory;
 
@@ -12,8 +13,17 @@ public class LoginBoxConfiguration extends HerokuConfiguration {
     @NotNull
     private HerokuDataSourceFactory dataSourceFactory = new HerokuDataSourceFactory();
 
+    @Valid
+    @NotNull
+    private PasswordValidatorFactory passwordValidatorFactory = new PasswordValidatorFactory();
+
     @JsonProperty("database")
     public HerokuDataSourceFactory getDataSourceFactory() {
         return this.dataSourceFactory;
+    }
+
+    @JsonProperty("password")
+    public PasswordValidatorFactory getPasswordValidatorFactory() {
+        return passwordValidatorFactory;
     }
 }

--- a/app/src/main/java/com/loginbox/app/config/Environment.java
+++ b/app/src/main/java/com/loginbox/app/config/Environment.java
@@ -1,0 +1,25 @@
+package com.loginbox.app.config;
+
+import java.util.function.Function;
+
+public class Environment {
+    /**
+     * Returns a config value from the environment, converting it to the required type.
+     *
+     * @param name
+     *         the environment variable name to read.
+     * @param converter
+     *         a function that converts the string from the environment into the appropriate domain type.
+     * @param defaultValue
+     *         a default value to use if the environment variable is unset.
+     * @param <T>
+     *         the type of the config value to return.
+     * @return a @{code T} from the environment, or the default value.
+     */
+    public static <T> T config(String name, Function<? super String, ? extends T> converter, T defaultValue) {
+        String value = System.getenv(name);
+        if (value == null)
+            return defaultValue;
+        return converter.apply(value);
+    }
+}

--- a/app/src/main/java/com/loginbox/app/password/PasswordBundle.java
+++ b/app/src/main/java/com/loginbox/app/password/PasswordBundle.java
@@ -1,0 +1,26 @@
+package com.loginbox.app.password;
+
+import com.loginbox.app.LoginBoxConfiguration;
+import io.dropwizard.Bundle;
+import io.dropwizard.ConfiguredBundle;
+import io.dropwizard.setup.Bootstrap;
+import io.dropwizard.setup.Environment;
+
+public class PasswordBundle implements ConfiguredBundle<LoginBoxConfiguration> {
+    private PasswordValidator passwordValidator = null;
+
+    @Override
+    public void initialize(Bootstrap<?> bootstrap) {
+    }
+
+    @Override
+    public void run(LoginBoxConfiguration configuration, Environment environment) throws Exception {
+        this.passwordValidator = configuration
+                .getPasswordValidatorFactory()
+                .build();
+    }
+
+    public PasswordValidator getPasswordValidator() {
+        return passwordValidator;
+    }
+}

--- a/app/src/main/java/com/loginbox/app/password/PasswordValidator.java
+++ b/app/src/main/java/com/loginbox/app/password/PasswordValidator.java
@@ -3,6 +3,12 @@ package com.loginbox.app.password;
 import org.mindrot.jbcrypt.BCrypt;
 
 public class PasswordValidator {
+    private final int workFactor;
+
+    public PasswordValidator(int workFactor) {
+        this.workFactor = workFactor;
+    }
+
     public String digest(String password) {
         String salt = newSalt();
         String digest = BCrypt.hashpw(password, salt);
@@ -14,6 +20,6 @@ public class PasswordValidator {
     }
 
     protected String newSalt() {
-        return BCrypt.gensalt();
+        return BCrypt.gensalt(workFactor);
     }
 }

--- a/app/src/main/java/com/loginbox/app/password/config/PasswordValidatorFactory.java
+++ b/app/src/main/java/com/loginbox/app/password/config/PasswordValidatorFactory.java
@@ -1,0 +1,23 @@
+package com.loginbox.app.password.config;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.loginbox.app.config.Environment;
+import com.loginbox.app.password.PasswordValidator;
+
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+
+public class PasswordValidatorFactory {
+    @Min(4)
+    @Max(30)
+    private int workFactor = Environment.config("BCRYPT_WORK_FACTOR", Integer::valueOf, 10);
+
+    @JsonProperty
+    public int getWorkFactor() {
+        return workFactor;
+    }
+
+    public PasswordValidator build() {
+        return new PasswordValidator(workFactor);
+    }
+}

--- a/app/src/main/java/com/loginbox/app/setup/SetupBundle.java
+++ b/app/src/main/java/com/loginbox/app/setup/SetupBundle.java
@@ -37,10 +37,13 @@ public abstract class SetupBundle implements Bundle {
     public void run(Environment environment) {
         MybatisTransactor transactor = new MybatisTransactor(this::getSqlSessionFactory);
         Directories directories = new Directories();
-        PasswordValidator passwordValidator = new PasswordValidator();
         Gatekeeper setupGatekeeper = new Gatekeeper(transactor);
-        Bootstrap bootstrap = new Bootstrap(
-                directories, setupGatekeeper, passwordValidator);
+        Bootstrap bootstrap = new Bootstrap(directories, setupGatekeeper) {
+            @Override
+            protected PasswordValidator getPasswordValidator() {
+                return SetupBundle.this.getPasswordValidator();
+            }
+        };
         Validator validator = environment.getValidator();
 
         SetupResource setupResource = new SetupResource(
@@ -51,6 +54,8 @@ public abstract class SetupBundle implements Bundle {
         environment.jersey().register(setupResource);
         environment.jersey().register(redirectToSetupFilter);
     }
+
+    public abstract PasswordValidator getPasswordValidator();
 
     public abstract SqlSessionFactory getSqlSessionFactory();
 }

--- a/app/src/test/java/com/loginbox/app/directory/bootstrap/BootstrapTest.java
+++ b/app/src/test/java/com/loginbox/app/directory/bootstrap/BootstrapTest.java
@@ -33,7 +33,12 @@ public class BootstrapTest extends TransactorTestCase {
     private final Gatekeeper setupGatekeeper = new Gatekeeper(setupTransactor);
 
     private final Bootstrap bootstrap
-            = new Bootstrap(directories, setupGatekeeper, passwordValidator);
+            = new Bootstrap(directories, setupGatekeeper) {
+        @Override
+        protected PasswordValidator getPasswordValidator() {
+            return passwordValidator;
+        }
+    };
 
     private final GatekeeperRepository gatekeeperRepository = mockMapper(GatekeeperRepository.class);
     private final InternalDirectoryQueries queries = mockMapper(InternalDirectoryQueries.class);
@@ -50,7 +55,6 @@ public class BootstrapTest extends TransactorTestCase {
     @Before
     public void wireMocks() {
         when(directoryRepository.insertInternalDirectory()).thenReturn(newDirectoryConfig);
-        when(newDirectoryConfig.getId()).thenReturn(directoryId);
 
         when(userInfo.withDigestedPassword(passwordValidator)).thenReturn(digestedUserInfo);
 

--- a/app/src/test/java/com/loginbox/app/setup/SetupBundleTest.java
+++ b/app/src/test/java/com/loginbox/app/setup/SetupBundleTest.java
@@ -1,6 +1,7 @@
 package com.loginbox.app.setup;
 
 import com.loginbox.app.dropwizard.BundleTestCase;
+import com.loginbox.app.password.PasswordValidator;
 import com.loginbox.app.setup.filters.RedirectToSetupFilter;
 import com.loginbox.app.setup.resources.SetupResource;
 import org.apache.ibatis.session.SqlSessionFactory;
@@ -13,7 +14,15 @@ import static org.mockito.Mockito.verify;
 public class SetupBundleTest extends BundleTestCase {
 
     private final SqlSessionFactory sqlSessionFactory = mock(SqlSessionFactory.class);
+    private final PasswordValidator passwordValidator = mock(PasswordValidator.class);
+
     private final SetupBundle bundle = new SetupBundle() {
+        @Override
+        public PasswordValidator getPasswordValidator() {
+            return passwordValidator;
+        }
+
+        @Override
         public SqlSessionFactory getSqlSessionFactory() {
             return sqlSessionFactory;
         }


### PR DESCRIPTION
Being able to tune the password strength is a necessary step for controlling site security policies. The default is "reasonable" as of this writing (~2^10 rounds) but should not be locked in stone.

Centralizing it in its own bundle ensures that all callers receive a sensibly-configured validator.
