### PR TITLE
Hoist directory ownership out to its own bundle.

### DIFF
--- a/app/src/main/java/com/loginbox/app/LoginBox.java
+++ b/app/src/main/java/com/loginbox/app/LoginBox.java
@@ -4,6 +4,8 @@ import com.loginbox.app.admin.AdminBundle;
 import com.loginbox.app.csrf.CsrfBundle;
 import com.loginbox.app.csrf.mybatis.MybatisCsrfBundle;
 import com.loginbox.app.csrf.ui.CsrfUiBundle;
+import com.loginbox.app.directory.Directories;
+import com.loginbox.app.directory.DirectoryBundle;
 import com.loginbox.app.landing.LandingBundle;
 import com.loginbox.app.password.PasswordBundle;
 import com.loginbox.app.password.PasswordValidator;
@@ -55,10 +57,16 @@ public class LoginBox extends Application<LoginBoxConfiguration> {
     private final PasswordBundle passwordBundle = new PasswordBundle();
     private final LandingBundle landingBundle = new LandingBundle();
     private final AdminBundle adminBundle = new AdminBundle();
+    private final DirectoryBundle directoryBundle = new DirectoryBundle();
     private final SetupBundle setupBundle = new SetupBundle() {
         @Override
         public PasswordValidator getPasswordValidator() {
             return passwordBundle.getPasswordValidator();
+        }
+
+        @Override
+        public Directories getDirectories() {
+            return directoryBundle.getDirectories();
         }
 
         @Override
@@ -80,6 +88,7 @@ public class LoginBox extends Application<LoginBoxConfiguration> {
         bootstrap.addBundle(passwordBundle);
         bootstrap.addBundle(landingBundle);
         bootstrap.addBundle(adminBundle);
+        bootstrap.addBundle(directoryBundle);
         bootstrap.addBundle(setupBundle);
     }
 

--- a/app/src/main/java/com/loginbox/app/directory/Directories.java
+++ b/app/src/main/java/com/loginbox/app/directory/Directories.java
@@ -7,19 +7,13 @@ import com.loginbox.transactor.transactable.Transform;
 import org.apache.ibatis.session.SqlSession;
 
 import static com.loginbox.app.transactor.mybatis.MybatisAdapters.mapper;
-import static com.loginbox.transactor.transactable.Transform.lift;
 
 public class Directories {
-    public Query<SqlSession, InternalDirectory> createInternalDirectory() {
-        Query<SqlSession, InternalDirectoryConfiguration> insertStep
-                = mapper(DirectoryRepository.class)
-                .around(DirectoryRepository::insertInternalDirectory);
-
-        Transform<SqlSession, InternalDirectoryConfiguration, InternalDirectory> configureStep
-                = lift(this::configureInternalDirectory);
-
-        return insertStep
-                .transformedBy(configureStep);
+    public InternalDirectory createInternalDirectory(SqlSession sqlSession) {
+        DirectoryRepository repository = sqlSession.getMapper(DirectoryRepository.class);
+        InternalDirectoryConfiguration configuration = repository.insertInternalDirectory();
+        InternalDirectory directory = configureInternalDirectory(configuration);
+        return directory;
     }
 
     private InternalDirectory configureInternalDirectory(InternalDirectoryConfiguration configuration) {

--- a/app/src/main/java/com/loginbox/app/directory/DirectoryBundle.java
+++ b/app/src/main/java/com/loginbox/app/directory/DirectoryBundle.java
@@ -1,0 +1,30 @@
+package com.loginbox.app.directory;
+
+import io.dropwizard.Bundle;
+import io.dropwizard.setup.Bootstrap;
+import io.dropwizard.setup.Environment;
+
+/**
+ * Provides an instance of {@link Directories}, configured for the current application.
+ */
+public class DirectoryBundle implements Bundle {
+    private Directories directories = new Directories();
+
+    @Override
+    public void initialize(Bootstrap<?> bootstrap) {
+
+    }
+
+    @Override
+    public void run(Environment environment) {
+
+    }
+
+    /**
+     * @return a {@link com.loginbox.app.directory.Directories} for the current application. This is only guaranteed to
+     * be non-{@code null} after calling {@link #run(io.dropwizard.setup.Environment)}.
+     */
+    public Directories getDirectories() {
+        return directories;
+    }
+}

--- a/app/src/main/java/com/loginbox/app/directory/bootstrap/Bootstrap.java
+++ b/app/src/main/java/com/loginbox/app/directory/bootstrap/Bootstrap.java
@@ -6,13 +6,8 @@ import com.loginbox.app.directory.internal.InternalDirectoryQueries;
 import com.loginbox.app.identity.User;
 import com.loginbox.app.identity.UserInfo;
 import com.loginbox.app.password.PasswordValidator;
-import com.loginbox.transactor.transactable.Action;
-import com.loginbox.transactor.transactable.Merge;
-import com.loginbox.transactor.transactable.Query;
 import com.loginbox.transactor.transactable.Transform;
 import org.apache.ibatis.session.SqlSession;
-
-import static com.loginbox.app.transactor.mybatis.MybatisAdapters.mapper;
 
 public abstract class Bootstrap {
     private final Gatekeeper setupGatekeeper;
@@ -21,44 +16,23 @@ public abstract class Bootstrap {
         this.setupGatekeeper = setupGatekeeper;
     }
 
-    private static <C, I, O> Transform<I, C, O> pivot(Transform<? super C, ? super I, ? extends O> t) {
-        return (context, input) -> t.apply(input, context);
-    }
-
     public Transform<SqlSession, UserInfo, User> setupAction() {
-        Query<SqlSession, PasswordValidator> passwordValidator
-                = Query.lift(this::getPasswordValidator);
+        PasswordValidator passwordValidator = getPasswordValidator();
 
-        Merge<SqlSession, UserInfo, PasswordValidator, UserInfo> digestUserInfoAgainstValidator
-                = Merge.lift(UserInfo::withDigestedPassword);
+        Transform<SqlSession, UserInfo, User> setupAction = (session, userInfo) -> {
+            UserInfo digestedUserInfo = userInfo.withDigestedPassword(passwordValidator);
 
-        Transform<SqlSession, Directories, InternalDirectory> createInternalDirectoryInDirectories
-                = pivot(Directories::createInternalDirectory);
+            Directories directories = getDirectories();
+            InternalDirectory internalDirectory = directories.createInternalDirectory(session);
 
-        Merge<SqlSession, InternalDirectory, UserInfo, User> addInitialUserToDirectory
-                = mapper(InternalDirectoryQueries.class)
-                .around(InternalDirectoryQueries::insertUser);
+            User user = session
+                    .getMapper(InternalDirectoryQueries.class)
+                    .insertUser(internalDirectory, digestedUserInfo);
 
-        Action<SqlSession> bootstrapCompletedAction = setupGatekeeper.bootstrapCompletedAction();
-
-        Query<SqlSession, Directories> directories = Query.lift(this::getDirectories);
-
-        Query<SqlSession, InternalDirectory> createInternalDirectory
-                = directories.transformedBy(createInternalDirectoryInDirectories);
-
-        Transform<SqlSession, UserInfo, User> addInitialUserToNewDirectory
-                = createInternalDirectory.intoLeft(addInitialUserToDirectory);
-
-        Transform<SqlSession, UserInfo, UserInfo> digestUserInfo
-                = passwordValidator.intoRight(digestUserInfoAgainstValidator);
-
-        Transform<SqlSession, UserInfo, User> addDigestedInitialUserToNewDirectory
-                = digestUserInfo.transformedBy(addInitialUserToNewDirectory);
-
-        Transform<SqlSession, UserInfo, User> bootstrap = addDigestedInitialUserToNewDirectory
-                .andThen(bootstrapCompletedAction);
-
-        return bootstrap;
+            return user;
+        };
+        return setupAction
+                .andThen(setupGatekeeper.bootstrapCompletedAction());
     }
 
     protected abstract PasswordValidator getPasswordValidator();

--- a/app/src/main/java/com/loginbox/app/setup/SetupBundle.java
+++ b/app/src/main/java/com/loginbox/app/setup/SetupBundle.java
@@ -36,9 +36,13 @@ public abstract class SetupBundle implements Bundle {
     @Override
     public void run(Environment environment) {
         MybatisTransactor transactor = new MybatisTransactor(this::getSqlSessionFactory);
-        Directories directories = new Directories();
         Gatekeeper setupGatekeeper = new Gatekeeper(transactor);
-        Bootstrap bootstrap = new Bootstrap(directories, setupGatekeeper) {
+        Bootstrap bootstrap = new Bootstrap(setupGatekeeper) {
+            @Override
+            public Directories getDirectories() {
+                return SetupBundle.this.getDirectories();
+            }
+
             @Override
             protected PasswordValidator getPasswordValidator() {
                 return SetupBundle.this.getPasswordValidator();
@@ -56,6 +60,8 @@ public abstract class SetupBundle implements Bundle {
     }
 
     public abstract PasswordValidator getPasswordValidator();
+
+    public abstract Directories getDirectories();
 
     public abstract SqlSessionFactory getSqlSessionFactory();
 }

--- a/app/src/test/java/com/loginbox/app/LoginBoxTest.java
+++ b/app/src/test/java/com/loginbox/app/LoginBoxTest.java
@@ -4,6 +4,7 @@ import com.loginbox.app.admin.AdminBundle;
 import com.loginbox.app.csrf.CsrfBundle;
 import com.loginbox.app.csrf.mybatis.MybatisCsrfBundle;
 import com.loginbox.app.csrf.ui.CsrfUiBundle;
+import com.loginbox.app.directory.DirectoryBundle;
 import com.loginbox.app.dropwizard.BundleTestCase;
 import com.loginbox.app.landing.LandingBundle;
 import com.loginbox.app.setup.SetupBundle;
@@ -37,6 +38,7 @@ public class LoginBoxTest extends BundleTestCase {
         verify(bootstrap).addBundle(isA(CsrfUiBundle.class));
         verify(bootstrap).addBundle(isA(LandingBundle.class));
         verify(bootstrap).addBundle(isA(AdminBundle.class));
+        verify(bootstrap).addBundle(isA(DirectoryBundle.class));
         verify(bootstrap).addBundle(isA(SetupBundle.class));
     }
 }

--- a/app/src/test/java/com/loginbox/app/directory/DirectoriesTest.java
+++ b/app/src/test/java/com/loginbox/app/directory/DirectoriesTest.java
@@ -24,9 +24,7 @@ public class DirectoriesTest extends TransactorTestCase {
         InternalDirectoryConfiguration directoryConfiguration = new InternalDirectoryConfiguration(id);
         when(directoryRepository.insertInternalDirectory()).thenReturn(directoryConfiguration);
 
-        Query<SqlSession, InternalDirectory> createQuery = directories.createInternalDirectory();
-
-        InternalDirectory directory = createQuery.fetch(sqlSession);
+        InternalDirectory directory = directories.createInternalDirectory(sqlSession);
 
         assertThat(directory.getId(), is(id));
     }

--- a/app/src/test/java/com/loginbox/app/directory/DirectoryBundleTest.java
+++ b/app/src/test/java/com/loginbox/app/directory/DirectoryBundleTest.java
@@ -1,0 +1,21 @@
+package com.loginbox.app.directory;
+
+import com.loginbox.app.dropwizard.BundleTestCase;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+
+public class DirectoryBundleTest extends BundleTestCase {
+    protected final DirectoryBundle bundle = new DirectoryBundle();
+
+    @Test
+    public void createsDirectories() {
+        bundle.initialize(bootstrap);
+        bundle.run(environment);
+
+        Directories directories = bundle.getDirectories();
+        assertThat(directories, not(nullValue()));
+    }
+}

--- a/app/src/test/java/com/loginbox/app/directory/bootstrap/BootstrapTest.java
+++ b/app/src/test/java/com/loginbox/app/directory/bootstrap/BootstrapTest.java
@@ -33,10 +33,15 @@ public class BootstrapTest extends TransactorTestCase {
     private final Gatekeeper setupGatekeeper = new Gatekeeper(setupTransactor);
 
     private final Bootstrap bootstrap
-            = new Bootstrap(directories, setupGatekeeper) {
+            = new Bootstrap(setupGatekeeper) {
         @Override
         protected PasswordValidator getPasswordValidator() {
             return passwordValidator;
+        }
+
+        @Override
+        protected Directories getDirectories() {
+            return directories;
         }
     };
 

--- a/app/src/test/java/com/loginbox/app/setup/SetupBundleTest.java
+++ b/app/src/test/java/com/loginbox/app/setup/SetupBundleTest.java
@@ -1,5 +1,6 @@
 package com.loginbox.app.setup;
 
+import com.loginbox.app.directory.Directories;
 import com.loginbox.app.dropwizard.BundleTestCase;
 import com.loginbox.app.password.PasswordValidator;
 import com.loginbox.app.setup.filters.RedirectToSetupFilter;
@@ -13,6 +14,7 @@ import static org.mockito.Mockito.verify;
 
 public class SetupBundleTest extends BundleTestCase {
 
+    private final Directories directories = mock(Directories.class);
     private final SqlSessionFactory sqlSessionFactory = mock(SqlSessionFactory.class);
     private final PasswordValidator passwordValidator = mock(PasswordValidator.class);
 
@@ -20,6 +22,11 @@ public class SetupBundleTest extends BundleTestCase {
         @Override
         public PasswordValidator getPasswordValidator() {
             return passwordValidator;
+        }
+
+        @Override
+        public Directories getDirectories() {
+            return directories;
         }
 
         @Override


### PR DESCRIPTION
This is prep work for the login bundle, which will need to share the directory
system.

I've re-applied Coda Hale's idiom for dependency injection using abstract
methods here, which makes `Bootstrap` feel a tiny bit inconsistent, but it's
probably the smoothest way to late-bind a bundle-provided dependency for a
component like `Bootstrap`. We'll see.

The Transactor system is a bloody hazard to refactoring.